### PR TITLE
Set parameter `$blnFixDomain` as intermediate fix

### DIFF
--- a/TL_ROOT/system/modules/backboneit_navigation/AbstractModuleNavigation.php
+++ b/TL_ROOT/system/modules/backboneit_navigation/AbstractModuleNavigation.php
@@ -442,7 +442,7 @@ abstract class AbstractModuleNavigation extends Module {
 					}
 
 					if(!$objNext->numRows) {
-						$arrPage['href'] = $this->generateFrontendUrl($arrPage);
+						$arrPage['href'] = $this->generateFrontendUrl($arrPage, null, null, true);
 
 					} elseif($objNext->type == 'redirect') {
 						$arrPage['href'] = $this->encodeEmailURL($objNext->url);
@@ -450,11 +450,11 @@ abstract class AbstractModuleNavigation extends Module {
 
 					} else {
 						$arrPage['tid'] = $objNext->id;
-						$arrPage['href'] = $this->generateFrontendUrl($objNext->row());
+						$arrPage['href'] = $this->generateFrontendUrl($objNext->row(), null, null, true);
 					}
 				} else {
 					$arrPage['tid'] = $arrPage['jumpTo'];
-					$arrPage['href'] = $this->generateFrontendUrl($arrPage);
+					$arrPage['href'] = $this->generateFrontendUrl($arrPage, null, null, true);
 				}
 				break;
 
@@ -475,7 +475,7 @@ abstract class AbstractModuleNavigation extends Module {
 			case 'regular':
 			case 'error_403':
 			case 'error_404':
-				$arrPage['href'] = $this->generateFrontendUrl($arrPage);
+				$arrPage['href'] = $this->generateFrontendUrl($arrPage, null, null, true);
 				break;
 		}
 


### PR DESCRIPTION
This is needed to be compatible with contao 4+

For Contao 5 the whole rendering must be changed as `Controller::generateFrontendUrl()` is deprecated:
> @deprecated Deprecated since Contao 4.2, to be removed in Contao 5.0.
> Use the contao.routing.url_generator service or PageModel::getFrontendUrl() instead.